### PR TITLE
update rest-client dependency to 1.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-pushbullet (0.1.3)
       json
-      rest-client (~> 1.7.2)
+      rest-client (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -24,17 +24,21 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     ffi (1.9.8-java)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.2)
     json (1.8.2-java)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.99)
     minitest (5.5.1)
     multi_json (1.10.1)
-    netrc (0.10.2)
+    netrc (0.11.0)
     parser (2.2.0.2)
       ast (>= 1.1, < 3.0)
     powerpack (0.0.9)
@@ -49,7 +53,8 @@ GEM
       spoon (~> 0.0)
     rainbow (2.0.0)
     rake (10.4.2)
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (3.0.0)
@@ -85,6 +90,10 @@ GEM
     thread_safe (0.3.4-java)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf (0.1.4-java)
+    unf_ext (0.0.7.1)
     vcr (2.9.3)
     webmock (1.20.4)
       addressable (>= 2.3.6)
@@ -107,3 +116,6 @@ DEPENDENCIES
   simplecov
   vcr
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/ruby-pushbullet.gemspec
+++ b/ruby-pushbullet.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'vcr'
   gem.add_development_dependency 'simplecov'
 
-  gem.add_dependency 'rest-client', '~> 1.7.2'
+  gem.add_dependency 'rest-client', '~> 1.8.0'
   gem.add_dependency 'json'
 end


### PR DESCRIPTION
updating rest-client to 1.8.0.
some useful gems require rest-client 1.8, but ruby-pushbullet require 1.7.2. I cannot use them together.
